### PR TITLE
Add EKS Fargate Terraform example

### DIFF
--- a/eks/README.md
+++ b/eks/README.md
@@ -1,0 +1,18 @@
+# EKS Fargate Terraform
+
+This directory contains Terraform configuration for a basic Amazon EKS cluster
+that runs workloads on Fargate. It uses the default VPC and automatically
+selects only those subnets in availability zones supported by EKS. By default
+the configuration excludes the `us-east-1e` zone, which is not available for EKS
+control plane instances.
+
+## Usage
+
+```
+terraform init
+terraform apply
+```
+
+Customize the variables in `variables.tf` if you need to change the cluster name
+or AWS region. You can also adjust the `excluded_azs` variable if additional
+availability zones should be omitted.

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -1,0 +1,111 @@
+# Fetch default VPC and subnets
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_availability_zones" "available" {}
+
+locals {
+  supported_azs = [for az in data.aws_availability_zones.available.names : az if !(contains(var.excluded_azs, az))]
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+
+  filter {
+    name   = "availability-zone"
+    values = local.supported_azs
+  }
+}
+
+# IAM role for the EKS cluster
+resource "aws_iam_role" "eks_cluster" {
+  name = "${var.cluster_name}-cluster-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Action = "sts:AssumeRole",
+      Effect = "Allow",
+      Principal = {
+        Service = "eks.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSClusterPolicy" {
+  role       = aws_iam_role.eks_cluster.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSServicePolicy" {
+  role       = aws_iam_role.eks_cluster.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+}
+
+# IAM role for Fargate pod execution
+resource "aws_iam_role" "fargate_pod_execution" {
+  name = "${var.cluster_name}-pod-exec-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Action = "sts:AssumeRole",
+      Effect = "Allow",
+      Principal = {
+        Service = "eks-fargate-pods.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "fargate_pod_execution" {
+  role       = aws_iam_role.fargate_pod_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy"
+}
+
+# EKS cluster
+resource "aws_eks_cluster" "this" {
+  name     = var.cluster_name
+  role_arn = aws_iam_role.eks_cluster.arn
+
+  vpc_config {
+    subnet_ids = data.aws_subnets.default.ids
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy,
+    aws_iam_role_policy_attachment.cluster_AmazonEKSServicePolicy
+  ]
+}
+
+# Fargate profile
+resource "aws_eks_fargate_profile" "default" {
+  cluster_name           = aws_eks_cluster.this.name
+  fargate_profile_name   = "default"
+  pod_execution_role_arn = aws_iam_role.fargate_pod_execution.arn
+  subnet_ids             = data.aws_subnets.default.ids
+
+  selector {
+    namespace = "default"
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.fargate_pod_execution]
+}
+
+output "cluster_name" {
+  value = aws_eks_cluster.this.name
+}
+
+output "cluster_endpoint" {
+  value = aws_eks_cluster.this.endpoint
+}
+
+output "cluster_arn" {
+  value = aws_eks_cluster.this.arn
+}

--- a/eks/providers.tf
+++ b/eks/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -1,0 +1,17 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+  default     = "demo-fargate"
+}
+
+variable "excluded_azs" {
+  description = "List of availability zones that should not be used for control plane subnets"
+  type        = list(string)
+  default     = ["us-east-1e"]
+}


### PR DESCRIPTION
## Summary
- add new `eks` folder with terraform code for creating an EKS cluster
- use a Fargate profile so workloads run on Fargate
- document usage in `eks/README.md`
- filter out unsupported AZs when choosing subnets for the cluster

## Testing
- `npm test` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_68451022cad8832eac45e13d24484784